### PR TITLE
Manual Triggers and Workflow Naming

### DIFF
--- a/.github/workflows/bunTest.yaml
+++ b/.github/workflows/bunTest.yaml
@@ -1,4 +1,4 @@
-name: Bun Test 🧪
+name: Bun Test
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
     paths:
       - "test/bun/**"
       - ".github/workflows/bunTest.yaml"
+  workflow_dispatch:
 
 jobs:
   bunTest:

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -1,4 +1,4 @@
-name: Docker Build & Push
+name: Build Docker Image and Push to Registry
 
 on:
   push:

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -1,4 +1,4 @@
-name: Build Docker Image and Push to Registry
+name: Docker Build & Push
 
 on:
   push:
@@ -13,6 +13,7 @@ on:
       - "DockerFile"
       - "Dockerfile"
       - ".github/workflows/dockerbuild.yaml"
+  workflow_dispatch:
 
 jobs:
   dockerbuild:

--- a/.github/workflows/ghcr_delete.yaml
+++ b/.github/workflows/ghcr_delete.yaml
@@ -1,4 +1,4 @@
-name: Delete Images from Registry
+name: GHCR Image Cleanup
 
 on:
   push:
@@ -15,6 +15,7 @@ on:
       - "Dockerfile"
       - ".github/workflows/dockerbuild.yaml"
       - ".github/workflows/ghcr_delete.yaml"
+  workflow_dispatch:
 
 jobs:
   ghcr_delete:

--- a/.github/workflows/lcov.yaml
+++ b/.github/workflows/lcov.yaml
@@ -1,4 +1,4 @@
-name: Lcov Test
+name: LCOV Coverage Analysis
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
       - "lcov/**"
       - "test/bun/coverage/**"
       - ".github/workflows/lcov.yaml"
+  workflow_dispatch:
 
 jobs:
   lcov:

--- a/.github/workflows/mavenbuild.yaml
+++ b/.github/workflows/mavenbuild.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - "mavenbuild/**"
       - ".github/workflows/mavenbuild.yaml"
+  workflow_dispatch:
 
 jobs:
   mavenbuild:

--- a/.github/workflows/maventest.yaml
+++ b/.github/workflows/maventest.yaml
@@ -1,4 +1,4 @@
-name: Maven Test 🧪
+name: Maven Test
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
     paths:
       - "test/mvn/**"
       - ".github/workflows/mavenTest.yaml"
+  workflow_dispatch:
 
 jobs:
   mavenTest:

--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -1,9 +1,10 @@
-name: 🏷️ Tags Versioning
+name: Git Tagging & Versioning
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   lcov:

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,4 +1,4 @@
-name: Versioning Test
+name: Automated Versioning
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
     paths:
       - "version/**"
       - ".github/workflows/version.yaml"
+  workflow_dispatch:
 
 jobs:
   lcov:


### PR DESCRIPTION
This PR adds 'workflow_dispatch' to all workflows to allow manual triggering from the GitHub Actions tab. It also standardizes and improves the naming of the workflows.