### PR TITLE
feat(dockerbuild): add tag_strategy support for run_number

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -49,3 +49,20 @@ jobs:
           image_name: kanggara75/devops
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  dockerbuild_run_number:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    name: Build and Push with Run Number
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: KAnggara/DevOps/dockerbuild@feature-dockerBuild
+        with:
+          path: action_test/bun
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tag_strategy: run_number

--- a/dockerbuild/action.yaml
+++ b/dockerbuild/action.yaml
@@ -23,6 +23,10 @@ inputs:
     description: "Image name (default repository)"
     required: false
     default: "${{ github.repository }}"
+  tag_strategy:
+    description: "Strategy for tagging release images on main/master (date or run_number)"
+    required: false
+    default: "date"
 
 runs:
   using: "composite"
@@ -38,6 +42,8 @@ runs:
         DOCKERFILE: ${{ inputs.dockerfile_path }}
         IMAGE_NAME: ${{ inputs.image_name }}
         BRANCH: ${{ github.head_ref || github.ref_name }}
+        TAG_STRATEGY: ${{ inputs.tag_strategy }}
+        RUN_NUMBER: ${{ github.run_number }}
       run: $GITHUB_ACTION_PATH/build.sh
 
     - name: Remove Docker credentials

--- a/dockerbuild/build.sh
+++ b/dockerbuild/build.sh
@@ -30,7 +30,11 @@ docker_build() {
 
   case "${BRANCH}" in
     main|master)
-      TAG1="release-${DATE}"
+      if [[ "${TAG_STRATEGY:-date}" == "run_number" && -n "${RUN_NUMBER:-}" ]]; then
+        TAG1="release-${RUN_NUMBER}"
+      else
+        TAG1="release-${DATE}"
+      fi
       ;;
     feature-*)
       TAG1="sit-${SHORT_SHA}"


### PR DESCRIPTION
Adds the ability to use github run_number instead of just DATE for docker build tags, and includes a test case.